### PR TITLE
Avatar size limit refactoring

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -185,6 +185,6 @@ module Greenlight
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
 
     # Max avatar image size
-    config.max_avatar_size = ENV['AVATAR_SIZE_LIMIT'].to_i
+    config.max_avatar_size = ENV['MAX_AVATAR_SIZE'].to_i.zero? ? 100000 : ENV['MAX_AVATAR_SIZE'].to_i
   end
 end

--- a/sample.env
+++ b/sample.env
@@ -357,5 +357,5 @@ DEFAULT_REGISTRATION=open
 # Default: 1
 #WEB_CONCURRENCY=1
 
-# Avatar image size limit (bytes)
-AVATAR_SIZE_LIMIT=100000
+# Max avatar image size (bytes)
+MAX_AVATAR_SIZE=100000


### PR DESCRIPTION
1. change the parameter name
2. set the default value (100k) in case MAX_AVATAR_SIZE is not set.